### PR TITLE
Fix a major crash

### DIFF
--- a/Dashboard Plugin/PluginController.h
+++ b/Dashboard Plugin/PluginController.h
@@ -3,7 +3,7 @@
 
 @interface PluginController : NSObject {
 
-	NSArray *badServerStrings;
+	NSMutableArray *badServerStrings;
 	
 }
 

--- a/Dashboard Plugin/PluginController.m
+++ b/Dashboard Plugin/PluginController.m
@@ -25,6 +25,7 @@ WebScriptObject *webScriptObject = nil;
 }
 
 -(void)dealloc {
+	[badServerStrings release];
 	[super dealloc];
 }
 

--- a/Dashboard Plugin/PluginController.m
+++ b/Dashboard Plugin/PluginController.m
@@ -12,7 +12,7 @@ WebScriptObject *webScriptObject = nil;
 	
 	[[NSDistributedNotificationCenter defaultCenter] addObserver:self selector:@selector(notificationRecieved:) name: @"com.apple.iTunes.playerInfo" object: nil];
 	
-	badServerStrings = nil;
+	badServerStrings = [[NSMutableArray alloc] init];
 	[self addServerErrorToClearList:@"lyricsdir"];
 	[self addServerErrorToClearList:@"Lyrics Directory"];
 	[self addServerErrorToClearList:@"Don't forget to donate to keep this great service running"];
@@ -197,14 +197,7 @@ WebScriptObject *webScriptObject = nil;
 }
 
 - (void) addServerErrorToClearList:(NSString *)errorString {
-	if (badServerStrings == nil) {
-		badServerStrings = [NSArray arrayWithObject:errorString];
-	}
-	else {
-		NSMutableArray *array = [NSMutableArray arrayWithArray:badServerStrings];
-		[array addObject:errorString];
-		badServerStrings = [NSArray arrayWithArray:array]; 
-	}
+	[badServerStrings addObject:errorString];
 }
 
 - (void) logMessage:(NSString *)str {


### PR DESCRIPTION
As soon as the widget tries to display lyrics, the plugin crash. I can't build the public version as I don't have the OS X 10.4 SDK and I don't want to break backward compatibility on the master branch.

I tested it real-quick on an other copy. After changing the base SDK and building everything, it seems to fix the issue.
